### PR TITLE
I am not sure about this fix RedeemSplit - Add Too Much To Split Throws Error

### DIFF
--- a/lib/redeemSplit.js
+++ b/lib/redeemSplit.js
@@ -15,13 +15,12 @@ const { addressToPubkeyhash, SATS_PER_BITCOIN } = require('./utils')
  satoshis and sent to the redeem address that was specified when the token was created.
 
  The tokenOwnerPrivateKey must own the existing STAS UTXO (stasUtxo),
- splitDestinations is an array containg the address and amount of the recipients of the tokens, the rest or the input will
+ splitDestinations is an array contains the address and amount of the recipients of the tokens, the rest or the input will
  be redeemed
  contractPublicKey is the redeem address
  paymentsPrivateKey owns the paymentUtxo and will be the owner of any change from the fee.
 */
 function redeemSplit (tokenOwnerPrivateKey, contractPublicKey, stasUtxo, splitDestinations, paymentUtxo, paymentsPrivateKey) {
-
   if (contractPublicKey === null) {
     throw new Error('contract public key is null')
   }
@@ -47,9 +46,11 @@ function redeemSplit (tokenOwnerPrivateKey, contractPublicKey, stasUtxo, splitDe
   // The first output is the change
   const version = getVersion(stasUtxo.scriptPubKey)
   const totalOutSats = splitDestinations.reduce((a, b) => a + Math.round(b.amount * SATS_PER_BITCOIN), 0)
-
+  const totalInSats = stasUtxo.amount
   const redeemSats = Math.round(stasUtxo.amount * SATS_PER_BITCOIN) - totalOutSats
-
+  if (totalOutSats >= totalInSats) {
+    throw new Error('Output satoshis cannot be greater or equal than total input satoshis')
+  }
   const publicKeyHash = bsv.crypto.Hash.sha256ripemd160(contractPublicKey.toBuffer()).toString('hex')
 
   const redeemScript = bsv.Script.fromASM(`OP_DUP OP_HASH160 ${publicKeyHash} OP_EQUALVERIFY OP_CHECKSIG`)

--- a/test/redeemSplit_test.js
+++ b/test/redeemSplit_test.js
@@ -177,15 +177,14 @@ it('RedeemSplit - No Split Completes Successfully', async function () {
   expect(await utils.getTokenBalance(bobAddr)).to.equal(6500)
 })
 
-//needs fixed - throwing 'Output satoshis is not a natural number' 
+// eslint-disable-next-line no-undef
 it('RedeemSplit - Add Too Much To Split Throws Error', async function () {
-
   const bobAmount = issueTx.vout[0].value * 2
   const splitDestinations = []
   splitDestinations[0] = { address: bobAddr, amount: bobAmount }
   const issueOutFundingVout = issueTx.vout.length - 1
   try {
-    const redeemHex = redeemSplit(
+    redeemSplit(
       alicePrivateKey,
       issuerPrivateKey.publicKey,
       utils.getUtxo(issueTxid, issueTx, 0),
@@ -197,7 +196,7 @@ it('RedeemSplit - Add Too Much To Split Throws Error', async function () {
     return
   } catch (e) {
     expect(e).to.be.instanceOf(Error)
-    expect(e.message).to.eql('Some Error')
+    expect(e.message).to.eql('Output satoshis cannot be greater or equal than total input satoshis')
   }
 })
 


### PR DESCRIPTION
It makes a lot of other tests fail (maybe it's ok since they are test that are supposed to throw errors):


 7) RedeemSplit - Address Too Long Throws Error:

      AssertionError: expected 'Output satoshis cannot be greater or equal than total input satoshis' to deeply equal 'Invalid Address string provided'
      + expected - actual

      -Output satoshis cannot be greater or equal than total input satoshis
      +Invalid Address string provided
      
      at Context.<anonymous> (test/redeemSplit_test.js:252:26)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)

  8) RedeemSplit - Incorrect Owner Private Key Throws Error:
     Error: Output satoshis cannot be greater or equal than total input satoshis
      at redeemSplit (lib/redeemSplit.js:52:11)
      at Context.<anonymous> (test/redeemSplit_test.js:266:21)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)

  9) RedeemSplit - Incorrect Funding Private Key Throws Error:
     Error: Output satoshis cannot be greater or equal than total input satoshis
      at redeemSplit (lib/redeemSplit.js:52:11)
      at Context.<anonymous> (test/redeemSplit_test.js:295:21)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)

